### PR TITLE
Implement Node.get_from_path

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ Unreleased
 - Improved test coverage and fixed numerous bugs
 - Implemented cache busting for static assets (images, CSS, and such). Use the
   ``cache-bust-glob`` option to control which files are cache busted.
+- Implemented ``Node.get_from_path`` which can fetch a
+  :class:`exhibition.main.Node` specified by a path
 
 .. _zero-zero-three:
 

--- a/exhibition/main.py
+++ b/exhibition/main.py
@@ -269,23 +269,24 @@ class Node:
         if not isinstance(path, pathlib.PurePath):
             path = pathlib.PurePath(path)
 
-        try:
-            if path.is_absolute():
-                found_node = self.root_node
-                for part in path.parts[1:]:
-                    found_node = found_node.children[part]
+        if path.is_absolute():
+            found_node = self.root_node
+            parts = path.parts[1:]
+        else:
+            if self.is_leaf:
+                found_node = self.parent
             else:
-                if self.is_leaf:
-                    found_node = self.parent
+                found_node = self
+            parts = path.parts
+
+        try:
+            for part in parts:
+                if part == ".":
+                    continue
+                elif part == "..":
+                    found_node = found_node.parent
                 else:
-                    found_node = self
-                for part in path.parts:
-                    if part == ".":
-                        continue
-                    elif part == "..":
-                        found_node = found_node.parent
-                    else:
-                        found_node = found_node.children[part]
+                    found_node = found_node.children[part]
         except KeyError as exp:
             raise OSError("{} could not find {}".format(self, exp.args)) from exp
 

--- a/exhibition/main.py
+++ b/exhibition/main.py
@@ -208,6 +208,9 @@ class Node:
 
         if self.parent:
             self.parent.add_child(self)
+            self.root_node = self.parent.root_node
+        else:
+            self.root_node = self
 
     @classmethod
     def from_path(cls, path, parent=None, meta=None):
@@ -268,12 +271,9 @@ class Node:
 
         try:
             if path.is_absolute():
-                if self.parent:
-                    found_node = self.parent.get_from_path(path)
-                else:
-                    found_node = self
-                    for part in path.parts[1:]:
-                        found_node = found_node.children[part]
+                found_node = self.root_node
+                for part in path.parts[1:]:
+                    found_node = found_node.children[part]
             else:
                 if self.is_leaf:
                     found_node = self.parent

--- a/exhibition/main.py
+++ b/exhibition/main.py
@@ -281,9 +281,7 @@ class Node:
 
         try:
             for part in parts:
-                if part == ".":
-                    continue
-                elif part == "..":
+                if part == "..":
                     found_node = found_node.parent
                 else:
                     found_node = found_node.children[part]

--- a/exhibition/tests/test_node.py
+++ b/exhibition/tests/test_node.py
@@ -586,3 +586,19 @@ class NodeTestCase(TestCase):
 
         with self.assertRaises(OSError):
             child_node.get_from_path(pathlib.Path("..", "not-a-page.html"))
+
+    def test_root_node_is_kept(self):
+        parent_path = pathlib.Path(self.content_path.name)
+        pathlib.Path(self.content_path.name, "images").mkdir()
+        pathlib.Path(self.content_path.name, "pages").mkdir()
+        child_path = pathlib.Path(self.content_path.name, "pages", "page.html")
+        child_path.touch()
+
+        parent_node = Node.from_path(parent_path)
+
+        self.assertEqual(parent_node.root_node, parent_node)
+        self.assertEqual(parent_node.children["pages"].root_node, parent_node)
+        self.assertEqual(parent_node.children["pages"].children["page.html"].root_node, parent_node)
+        self.assertEqual(parent_node.children["pages"].children["page.html"].parent.root_node, parent_node)
+        self.assertEqual(parent_node.children["pages"].children["page.html"].parent.parent.root_node, parent_node)
+        self.assertEqual(parent_node.children["pages"].children["page.html"].parent.parent.root_node, parent_node)

--- a/exhibition/tests/test_node.py
+++ b/exhibition/tests/test_node.py
@@ -521,7 +521,8 @@ class NodeTestCase(TestCase):
         child_node = parent_node.children["images"].children["bust-me.jpg"]
         target_node = parent_node.children["pages"].children["page.html"]
 
-        self.assertEqual(child_node.get_from_path(pathlib.Path("..", "pages", "page.html")), target_node)
+        self.assertEqual(child_node.get_from_path(pathlib.Path("..", "pages", "page.html")),
+                         target_node)
 
     def test_get_from_path_absolute_str(self):
         parent_path = pathlib.Path(self.content_path.name)
@@ -599,6 +600,13 @@ class NodeTestCase(TestCase):
         self.assertEqual(parent_node.root_node, parent_node)
         self.assertEqual(parent_node.children["pages"].root_node, parent_node)
         self.assertEqual(parent_node.children["pages"].children["page.html"].root_node, parent_node)
-        self.assertEqual(parent_node.children["pages"].children["page.html"].parent.root_node, parent_node)
-        self.assertEqual(parent_node.children["pages"].children["page.html"].parent.parent.root_node, parent_node)
-        self.assertEqual(parent_node.children["pages"].children["page.html"].parent.parent.root_node, parent_node)
+        self.assertEqual(parent_node.children["pages"].children["page.html"].parent.root_node,
+                         parent_node)
+        self.assertEqual(
+            parent_node.children["pages"].children["page.html"].parent.parent.root_node,
+            parent_node
+        )
+        self.assertEqual(
+            parent_node.children["pages"].children["page.html"].parent.parent.root_node,
+            parent_node
+        )

--- a/exhibition/tests/test_node.py
+++ b/exhibition/tests/test_node.py
@@ -490,3 +490,99 @@ class NodeTestCase(TestCase):
                                           "bust-me.{}.jpg".format(JSON_DIGEST))))
 
         self.assertEqual(child_node.full_url, "/bust-me.{}.jpg".format(JSON_DIGEST))
+
+    def test_get_from_path_relative_str(self):
+        parent_path = pathlib.Path(self.content_path.name)
+        pathlib.Path(self.content_path.name, "images").mkdir()
+        child1_path = pathlib.Path(self.content_path.name, "images", "bust-me.jpg")
+        child1_path.touch()
+        pathlib.Path(self.content_path.name, "pages").mkdir()
+        child2_path = pathlib.Path(self.content_path.name, "pages", "page.html")
+        child2_path.touch()
+
+        parent_node = Node.from_path(parent_path)
+
+        child_node = parent_node.children["images"].children["bust-me.jpg"]
+        target_node = parent_node.children["pages"].children["page.html"]
+
+        self.assertEqual(child_node.get_from_path("../pages/page.html"), target_node)
+
+    def test_get_from_path_relative_pathlib(self):
+        parent_path = pathlib.Path(self.content_path.name)
+        pathlib.Path(self.content_path.name, "images").mkdir()
+        child1_path = pathlib.Path(self.content_path.name, "images", "bust-me.jpg")
+        child1_path.touch()
+        pathlib.Path(self.content_path.name, "pages").mkdir()
+        child2_path = pathlib.Path(self.content_path.name, "pages", "page.html")
+        child2_path.touch()
+
+        parent_node = Node.from_path(parent_path)
+
+        child_node = parent_node.children["images"].children["bust-me.jpg"]
+        target_node = parent_node.children["pages"].children["page.html"]
+
+        self.assertEqual(child_node.get_from_path(pathlib.Path("..", "pages", "page.html")), target_node)
+
+    def test_get_from_path_absolute_str(self):
+        parent_path = pathlib.Path(self.content_path.name)
+        pathlib.Path(self.content_path.name, "images").mkdir()
+        child1_path = pathlib.Path(self.content_path.name, "images", "bust-me.jpg")
+        child1_path.touch()
+        pathlib.Path(self.content_path.name, "pages").mkdir()
+        child2_path = pathlib.Path(self.content_path.name, "pages", "page.html")
+        child2_path.touch()
+
+        parent_node = Node.from_path(parent_path)
+
+        child_node = parent_node.children["images"].children["bust-me.jpg"]
+        target_node = parent_node.children["pages"].children["page.html"]
+
+        self.assertEqual(child_node.get_from_path("/pages/page.html"), target_node)
+
+    def test_get_from_path_absolute_pathlib(self):
+        parent_path = pathlib.Path(self.content_path.name)
+        pathlib.Path(self.content_path.name, "images").mkdir()
+        child1_path = pathlib.Path(self.content_path.name, "images", "bust-me.jpg")
+        child1_path.touch()
+        pathlib.Path(self.content_path.name, "pages").mkdir()
+        child2_path = pathlib.Path(self.content_path.name, "pages", "page.html")
+        child2_path.touch()
+
+        parent_node = Node.from_path(parent_path)
+
+        child_node = parent_node.children["images"].children["bust-me.jpg"]
+        target_node = parent_node.children["pages"].children["page.html"]
+
+        self.assertEqual(child_node.get_from_path(pathlib.Path("/pages/page.html")), target_node)
+
+    def test_get_from_path_not_existing_from_str(self):
+        parent_path = pathlib.Path(self.content_path.name)
+        pathlib.Path(self.content_path.name, "images").mkdir()
+        child1_path = pathlib.Path(self.content_path.name, "images", "bust-me.jpg")
+        child1_path.touch()
+        pathlib.Path(self.content_path.name, "pages").mkdir()
+        child2_path = pathlib.Path(self.content_path.name, "pages", "page.html")
+        child2_path.touch()
+
+        parent_node = Node.from_path(parent_path)
+
+        child_node = parent_node.children["images"].children["bust-me.jpg"]
+
+        with self.assertRaises(OSError):
+            child_node.get_from_path("../not-a-page.html")
+
+    def test_get_from_path_not_existing_from_pathlib(self):
+        parent_path = pathlib.Path(self.content_path.name)
+        pathlib.Path(self.content_path.name, "images").mkdir()
+        child1_path = pathlib.Path(self.content_path.name, "images", "bust-me.jpg")
+        child1_path.touch()
+        pathlib.Path(self.content_path.name, "pages").mkdir()
+        child2_path = pathlib.Path(self.content_path.name, "pages", "page.html")
+        child2_path.touch()
+
+        parent_node = Node.from_path(parent_path)
+
+        child_node = parent_node.children["images"].children["bust-me.jpg"]
+
+        with self.assertRaises(OSError):
+            child_node.get_from_path(pathlib.Path("..", "not-a-page.html"))

--- a/exhibition/tests/test_node.py
+++ b/exhibition/tests/test_node.py
@@ -491,7 +491,7 @@ class NodeTestCase(TestCase):
 
         self.assertEqual(child_node.full_url, "/bust-me.{}.jpg".format(JSON_DIGEST))
 
-    def test_get_from_path_relative_str(self):
+    def test_get_from_path_relative_str_on_leaf(self):
         parent_path = pathlib.Path(self.content_path.name)
         pathlib.Path(self.content_path.name, "images").mkdir()
         child1_path = pathlib.Path(self.content_path.name, "images", "bust-me.jpg")
@@ -507,7 +507,7 @@ class NodeTestCase(TestCase):
 
         self.assertEqual(child_node.get_from_path("../pages/page.html"), target_node)
 
-    def test_get_from_path_relative_pathlib(self):
+    def test_get_from_path_relative_pathlib_on_leaf(self):
         parent_path = pathlib.Path(self.content_path.name)
         pathlib.Path(self.content_path.name, "images").mkdir()
         child1_path = pathlib.Path(self.content_path.name, "images", "bust-me.jpg")
@@ -522,6 +522,72 @@ class NodeTestCase(TestCase):
         target_node = parent_node.children["pages"].children["page.html"]
 
         self.assertEqual(child_node.get_from_path(pathlib.Path("..", "pages", "page.html")),
+                         target_node)
+
+    def test_get_from_path_relative_str_on_dir(self):
+        parent_path = pathlib.Path(self.content_path.name)
+        pathlib.Path(self.content_path.name, "images").mkdir()
+        child1_path = pathlib.Path(self.content_path.name, "images", "bust-me.jpg")
+        child1_path.touch()
+        pathlib.Path(self.content_path.name, "pages").mkdir()
+        child2_path = pathlib.Path(self.content_path.name, "pages", "page.html")
+        child2_path.touch()
+
+        parent_node = Node.from_path(parent_path)
+
+        child_node = parent_node.children["images"]
+        target_node = parent_node.children["pages"].children["page.html"]
+
+        self.assertEqual(child_node.get_from_path("../pages/page.html"), target_node)
+
+    def test_get_from_path_relative_pathlib_on_dir(self):
+        parent_path = pathlib.Path(self.content_path.name)
+        pathlib.Path(self.content_path.name, "images").mkdir()
+        child1_path = pathlib.Path(self.content_path.name, "images", "bust-me.jpg")
+        child1_path.touch()
+        pathlib.Path(self.content_path.name, "pages").mkdir()
+        child2_path = pathlib.Path(self.content_path.name, "pages", "page.html")
+        child2_path.touch()
+
+        parent_node = Node.from_path(parent_path)
+
+        child_node = parent_node.children["images"]
+        target_node = parent_node.children["pages"].children["page.html"]
+
+        self.assertEqual(child_node.get_from_path(pathlib.Path("..", "pages", "page.html")),
+                         target_node)
+
+    def test_get_from_path_relative_str_with_dot(self):
+        parent_path = pathlib.Path(self.content_path.name)
+        pathlib.Path(self.content_path.name, "images").mkdir()
+        child1_path = pathlib.Path(self.content_path.name, "images", "bust-me.jpg")
+        child1_path.touch()
+        pathlib.Path(self.content_path.name, "pages").mkdir()
+        child2_path = pathlib.Path(self.content_path.name, "pages", "page.html")
+        child2_path.touch()
+
+        parent_node = Node.from_path(parent_path)
+
+        child_node = parent_node.children["pages"]
+        target_node = parent_node.children["pages"].children["page.html"]
+
+        self.assertEqual(child_node.get_from_path("./page.html"), target_node)
+
+    def test_get_from_path_relative_pathlib_with_dot(self):
+        parent_path = pathlib.Path(self.content_path.name)
+        pathlib.Path(self.content_path.name, "images").mkdir()
+        child1_path = pathlib.Path(self.content_path.name, "images", "bust-me.jpg")
+        child1_path.touch()
+        pathlib.Path(self.content_path.name, "pages").mkdir()
+        child2_path = pathlib.Path(self.content_path.name, "pages", "page.html")
+        child2_path.touch()
+
+        parent_node = Node.from_path(parent_path)
+
+        child_node = parent_node.children["pages"]
+        target_node = parent_node.children["pages"].children["page.html"]
+
+        self.assertEqual(child_node.get_from_path(pathlib.Path(".", "page.html")),
                          target_node)
 
     def test_get_from_path_absolute_str(self):


### PR DESCRIPTION
Allow fetching another Node object from the tree via a pseudo-path, with the root "/" being the root Node.