### PR TITLE
Meta keys should have underscores, not hyphens

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,9 +8,10 @@ Unreleased
   attached to, making debuging missing keys far easier.
 - Improved test coverage and fixed numerous bugs
 - Implemented cache busting for static assets (images, CSS, and such). Use the
-  ``cache-bust-glob`` option to control which files are cache busted.
+  ``cache_bust_glob`` option to control which files are cache busted.
 - Implemented ``Node.get_from_path`` which can fetch a
   :class:`exhibition.main.Node` specified by a path
+- Make all Exhibition defined meta keys use underscores not hyphens
 
 .. _zero-zero-three:
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -75,13 +75,13 @@ If you wish to use template inheritance, add the following to ``site.yaml``:
 
 Where "mytemplates" is whatever directory you will store your templates in. You
 can either use the extends tag directly or you can specify ``extends`` in
-``site.yaml``. You can also specify ``default-block`` to save you from wrapping
+``site.yaml``. You can also specify ``default_block`` to save you from wrapping
 every page in ``{% block content %}``:
 
 .. code-block:: yaml
 
    extends: page.j2
-   default-block: content
+   default_block: content
 
 And then our template:
 
@@ -123,7 +123,7 @@ You can reference any data that you put in ``site.yaml`` like this - and
 there's no limit on what you can put in there.
 
 As well as ``site.yaml`` there are two additional places that settings can be
-controlled: ``meta.yaml`` and front matter.
+controlled: ``meta.yaml`` and frontmatter.
 
 Meta files
 ^^^^^^^^^^

--- a/docs/meta.rst
+++ b/docs/meta.rst
@@ -83,7 +83,7 @@ The dotted path notation that Exhibition can import to process content on a node
 
 Exhibition comes with one filter: ``exhibition.filters.jinja2``
 
-``filter-glob``
+``filter_glob``
 ^^^^^^^^^^^^^^^
 
 Matching files are processed by ``filter`` if specified, otherwise this option
@@ -91,14 +91,14 @@ does nothing.
 
 .. code-block:: yaml
 
-   filter-glob: "*.html"
+   filter_glob: "*.html"
 
-As glob patterns are fairly simple, ``filter-glob`` can also be a list of
+As glob patterns are fairly simple, ``filter_glob`` can also be a list of
 patterns:
 
 .. code-block:: yaml
 
-   filter-glob:
+   filter_glob:
      - "*.html"
      - "*.htm"
      - "robot.txt"
@@ -120,7 +120,7 @@ The path where Jinja2 templates will be found. Can be single string or a list.
 If specified, this will insert a ``{% extends %}`` statement at the beginning of
 the file content before it is passed to Jinja2.
 
-``default-block``
+``default_block``
 ~~~~~~~~~~~~~~~~~
 
 If specified, this will wrap the file content in ``{% block %}``.
@@ -138,7 +138,7 @@ Cache busting is an important tool that allows static assets (such as CSS
 files) to bypass the browser cache when the content of such files is updated,
 while still allowing high value expiry times.
 
-``cache-bust-glob``
+``cache_bust_glob``
 ^^^^^^^^^^^^^^^^^^^
 
 Matching files have their deployed path and URL changed to include a hash of
@@ -147,14 +147,14 @@ their contents. E.g. ``media/site.css`` might become
 
 .. code-block:: yaml
 
-   cache-bust-glob: "*.css"
+   cache_bust_glob: "*.css"
 
-As glob patterns are fairly simple, ``cache-bust-glob`` can also be a list of
+As glob patterns are fairly simple, ``cache_bust_glob`` can also be a list of
 patterns:
 
 .. code-block:: yaml
 
-   cache-bust-glob:
+   cache_bust_glob:
      - "*.css"
      - "*.jpg"
      - "*.jpeg"

--- a/exhibition/filters/jinja2.py
+++ b/exhibition/filters/jinja2.py
@@ -151,7 +151,7 @@ def content_filter(node, content):
     :param node:
         The node being rendered
     :param content:
-        The content of the node, stripped of any YAML front matter
+        The content of the node, stripped of any YAML frontmatter
     """
     env = Environment(
         loader=FileSystemLoader(node.meta["templates"]),
@@ -169,9 +169,9 @@ def content_filter(node, content):
     if node.meta.get("extends"):
         parts.append(EXTENDS_TEMPLATE_TEMPLATE % node.meta["extends"])
 
-    if node.meta.get("default-block"):
+    if node.meta.get("default_block"):
         parts.extend([
-            START_BLOCK_TEMPLATE % node.meta["default-block"],
+            START_BLOCK_TEMPLATE % node.meta["default_block"],
             content,
             END_BLOCK_TEMPLATE,
         ])

--- a/exhibition/main.py
+++ b/exhibition/main.py
@@ -413,7 +413,7 @@ class Node:
         """
         Get the actual content of the Node
 
-        First calls :meth:`process_meta` to find the end any front matter that
+        First calls :meth:`process_meta` to find the end any frontmatter that
         might be present and then returns the rest of the file
 
         If ``filter`` has been specified in :attr:`meta`, that filter will be
@@ -434,7 +434,7 @@ class Node:
 
             if content_filter is not None:
                 filter_module = import_module(content_filter)
-                globs = self.meta.get("filter-glob", filter_module.DEFAULT_GLOB)
+                globs = self.meta.get("filter_glob", filter_module.DEFAULT_GLOB)
                 if not isinstance(globs, (list, tuple)):
                     globs = [globs]
                 for filter_glob in globs:
@@ -449,7 +449,7 @@ class Node:
         """
         Configuration object
 
-        Automatically loads front-matter if applicable
+        Automatically loads frontmatter if applicable
         """
         self.process_meta()
         return self._meta
@@ -510,7 +510,7 @@ class Node:
             return self._cache_bust_version
 
         self._cache_bust_version = False
-        globs = self.meta.get("cache-bust-glob", [])
+        globs = self.meta.get("cache_bust_glob", [])
         if not isinstance(globs, (list, tuple)):
             globs = [globs]
         for cache_bust_glob in globs:

--- a/exhibition/tests/test_filters.py
+++ b/exhibition/tests/test_filters.py
@@ -144,7 +144,7 @@ class Jinja2TestCase(TestCase):
             self.assertEqual(result, "<p>Title</p>\n")
 
             node = Node(mock.Mock(), None, meta={"templates": [tmp_dir],
-                                                 "extends": "bob.j2", "default-block": "content"})
+                                                 "extends": "bob.j2", "default_block": "content"})
             node.is_leaf = False
             result = jinja_filter(node, PLAIN_TEMPLATE)
             self.assertEqual(result, "<p>Title</p>\n\n<p>0</p><p>1</p><p>2</p>")
@@ -288,7 +288,7 @@ class Jinja2TestCase(TestCase):
             node = Node(path, Node(path.parent, None, {"content_path": content_path,
                                                        "deploy_path": deploy_path,
                                                        "filter": "exhibition.filters.jinja2",
-                                                       "filter-glob": "*.htm",
+                                                       "filter_glob": "*.htm",
                                                        "templates": []}))
             node.render()
             with pathlib.Path(deploy_path, "blog.htm").open("r") as f:
@@ -305,7 +305,7 @@ class Jinja2TestCase(TestCase):
             node = Node(path, Node(path.parent, None, {"content_path": content_path,
                                                        "deploy_path": deploy_path,
                                                        "filter": "exhibition.filters.jinja2",
-                                                       "filter-glob": ["*.html", "*.htm"],
+                                                       "filter_glob": ["*.html", "*.htm"],
                                                        "templates": []}))
             node.render()
             with pathlib.Path(deploy_path, "blog.htm").open("r") as f:

--- a/exhibition/tests/test_node.py
+++ b/exhibition/tests/test_node.py
@@ -435,7 +435,7 @@ class NodeTestCase(TestCase):
 
         meta_path = pathlib.Path(self.content_path.name, "meta.yaml")
         with meta_path.open("w") as f:
-            f.write("cache-bust-glob: \"*.jpg\"")
+            f.write("cache_bust_glob: \"*.jpg\"")
 
         parent_node = Node.from_path(parent_path)
         parent_node.meta.update(**self.default_settings)
@@ -462,7 +462,7 @@ class NodeTestCase(TestCase):
 
         meta_path = pathlib.Path(self.content_path.name, "meta.yaml")
         with meta_path.open("w") as f:
-            f.write("cache-bust-glob:\n  - \"*.jpeg\"\n  - \"*.jpg\"")
+            f.write("cache_bust_glob:\n  - \"*.jpeg\"\n  - \"*.jpg\"")
 
         parent_node = Node.from_path(parent_path)
         parent_node.meta.update(**self.default_settings)
@@ -488,7 +488,7 @@ class NodeTestCase(TestCase):
 
         parent_node = Node.from_path(parent_path)
         parent_node.meta.update(**self.default_settings)
-        parent_node.meta["cache-bust-glob"] = "*"
+        parent_node.meta["cache_bust_glob"] = "*"
         self.assertCountEqual(parent_node.children.keys(), ["bust-me.jpg"])
 
         child_node = parent_node.children["bust-me.jpg"]
@@ -507,7 +507,7 @@ class NodeTestCase(TestCase):
 
         parent_node = Node.from_path(parent_path)
         parent_node.meta.update(**self.default_settings)
-        parent_node.meta["cache-bust-glob"] = "*"
+        parent_node.meta["cache_bust_glob"] = "*"
         self.assertCountEqual(parent_node.children.keys(), ["bust-me.jpg"])
 
         child_node = parent_node.children["bust-me.jpg"]


### PR DESCRIPTION
Fixes #42 

Not enforced for user created keys, this is only to make our documentation consistent. I.e. I don't have to remember if it's `cache-bust-glob` or `cache_bust_glob` if I can already see that I've used `filter_glob`