### PR TITLE
Add support for a Jinja2 pandoc filter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
       script: tox -e $TOX_ENV
 
 before_install:
+    - sudo apt update
     - sudo apt -y install pandoc
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ matrix:
       install: pip install tox
       script: tox -e $TOX_ENV
 
+before_install:
+    - sudo apt -y install pandoc
+
 install:
     - pip install tox-travis codecov
 

--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -42,6 +42,17 @@ keyword arguments.
 
 Please view the `Markdown documentation <https://python-markdown.github.io/>`_ for details.
 
+Pandoc
+^^^^^^
+
+``pandoc`` is provided as a filter and can be configured by the
+``pandoc_config`` meta variable, which is passed to the convert_text function
+as keyword arguments.
+
+Please refer `pypandoc project <https://github.com/bebraw/pypandoc>`_ for details.
+
+Note, pypandoc requires pandoc to be installed. It will display a warning without it.
+
 Typogrify
 ^^^^^^^^^
 

--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -51,7 +51,7 @@ as keyword arguments.
 
 Please refer `pypandoc project <https://github.com/bebraw/pypandoc>`_ for details.
 
-Note, pypandoc requires pandoc to be installed. It will display a warning without it.
+Note, pypandoc requires pandoc to be installed. It will error without it.
 
 Typogrify
 ^^^^^^^^^

--- a/exhibition/filters/jinja2.py
+++ b/exhibition/filters/jinja2.py
@@ -62,6 +62,7 @@ DEFAULT_PANDOC_KWARGS = {
 
 logger = logging.getLogger("exhibition")
 
+
 def metasort(nodes, key=None, reverse=False):
     """
     Sorts a list of nodes based on keys found in their meta objects
@@ -92,6 +93,7 @@ def markdown(ctx, text):
     kwargs.update(node.meta.get("markdown_config", {}))
 
     return md_func(text, **kwargs)
+
 
 @contextfilter
 def pandoc(ctx, text, fmt=None):

--- a/exhibition/filters/jinja2.py
+++ b/exhibition/filters/jinja2.py
@@ -30,7 +30,6 @@ To use, add the following to your configuration file:
 """
 
 from datetime import datetime, timezone
-import logging
 
 from jinja2 import Environment, FileSystemLoader, contextfilter
 from jinja2.exceptions import TemplateRuntimeError
@@ -58,8 +57,6 @@ DEFAULT_MD_KWARGS = {
 DEFAULT_PANDOC_KWARGS = {
     "to": "html",
 }
-
-logger = logging.getLogger("exhibition")
 
 
 def metasort(nodes, key=None, reverse=False):
@@ -104,12 +101,7 @@ def pandoc(ctx, text, fmt=None):
     if fmt is not None:
         kwargs["format"] = fmt
 
-    try:
-        return pandoc_func(text, **kwargs)
-    except OSError:
-        # Pandoc isn't installed.
-        logger.warning("Pandoc is not installed.")
-        return ""
+    return pandoc_func(text, **kwargs)
 
 
 class RaiseError(Extension):

--- a/exhibition/filters/jinja2.py
+++ b/exhibition/filters/jinja2.py
@@ -29,17 +29,16 @@ To use, add the following to your configuration file:
    filter: exhibition.filters.jinja2
 """
 
-import logging
 from datetime import datetime, timezone
+import logging
 
 from jinja2 import Environment, FileSystemLoader, contextfilter
 from jinja2.exceptions import TemplateRuntimeError
 from jinja2.ext import Extension
 from jinja2.nodes import CallBlock, Const, ContextReference
 from markdown import markdown as md_func
-from typogrify.templatetags import jinja_filters as typogrify_filters
 from pypandoc import convert_text as pandoc_func
-
+from typogrify.templatetags import jinja_filters as typogrify_filters
 
 EXTENDS_TEMPLATE_TEMPLATE = """{%% extends "%s" %%}
 """

--- a/exhibition/tests/test_filters.py
+++ b/exhibition/tests/test_filters.py
@@ -68,6 +68,15 @@ This is *text*
 {% endfilter %}
 """.strip()
 
+
+PANDOC_TEMPLATE = """
+{% filter pandoc("org") %}
+* Hello
+
+This /is/ *text*
+{% endfilter %}
+"""
+
 TYPOG_TEMPLATE = """
 {% filter typogrify %}
 Hello -- how are you?
@@ -242,6 +251,20 @@ class Jinja2TestCase(TestCase):
         node.is_leaf = False
         result = jinja_filter(node, MD_TEMPLATE)
         self.assertEqual(result, "<h2>Hello</h2>\n<p>This is <em>text</em></p>")
+
+    def test_pandoc_filter(self):
+        node = Node(mock.Mock(), None, meta={"templates": []})
+        node.is_leaf = False
+        try:
+            result = jinja_filter(node, PANDOC_TEMPLATE)
+        except OSError:
+            # Pandoc isn't installed.
+            pass
+        self.assertEqual(
+            result,
+            "\n<h1 id=\"hello\">Hello</h1>\n"
+            "<p>This <em>is</em> <strong>text</strong></p>\n"
+        )
 
     def test_typogrify_filter(self):
         node = Node(mock.Mock(), None, meta={"templates": []})

--- a/exhibition/tests/test_filters.py
+++ b/exhibition/tests/test_filters.py
@@ -77,6 +77,14 @@ This /is/ *text*
 {% endfilter %}
 """
 
+PANDOC_TEMPLATE_WITHOUT_ARG = """
+{% filter pandoc %}
+* Hello
+
+This /is/ *text*
+{% endfilter %}
+"""
+
 TYPOG_TEMPLATE = """
 {% filter typogrify %}
 Hello -- how are you?
@@ -261,6 +269,23 @@ class Jinja2TestCase(TestCase):
             "\n<h1 id=\"hello\">Hello</h1>\n"
             "<p>This <em>is</em> <strong>text</strong></p>\n"
         )
+
+    def test_pandoc_filter_no_argument(self):
+        meta = {"templates": []}
+        node = Node(mock.Mock(), None, meta=meta)
+        node.is_leaf = False
+
+        # First test with no arguments at all.
+        self.assertRaises(
+            TypeError,
+            jinja_filter,
+            node,
+            PANDOC_TEMPLATE_WITHOUT_ARG
+        )
+
+        node.meta["pandoc_config"] = {"format": "org", "to": "markdown"}
+        result = jinja_filter(node, PANDOC_TEMPLATE_WITHOUT_ARG)
+        self.assertEqual(result, "\nHello\n=====\n\nThis *is* **text**\n")
 
     def test_typogrify_filter(self):
         node = Node(mock.Mock(), None, meta={"templates": []})

--- a/exhibition/tests/test_filters.py
+++ b/exhibition/tests/test_filters.py
@@ -255,11 +255,7 @@ class Jinja2TestCase(TestCase):
     def test_pandoc_filter(self):
         node = Node(mock.Mock(), None, meta={"templates": []})
         node.is_leaf = False
-        try:
-            result = jinja_filter(node, PANDOC_TEMPLATE)
-        except OSError:
-            # Pandoc isn't installed.
-            pass
+        result = jinja_filter(node, PANDOC_TEMPLATE)
         self.assertEqual(
             result,
             "\n<h1 id=\"hello\">Hello</h1>\n"

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         "markdown",
         "ruamel.yaml",
         "typogrify",
+        "pypandoc",
     ],
     extras_require={
         "docs": [


### PR DESCRIPTION
This can now be used with the filter tag, e.g.

```html
{% filter pandoc("org") %}
stuff here.
{% endfilter %}
```