### PR TITLE
[WIP] Add support for watching for changes and re-generating

### DIFF
--- a/exhibition/command.py
+++ b/exhibition/command.py
@@ -26,6 +26,7 @@ Documentation for this module can be found in :doc:`commandline`
 import logging
 
 import click
+from watchdog.observers import Observer
 
 from . import __version__, config, utils
 
@@ -58,7 +59,8 @@ def gen():
 @exhibition.command(short_help="Serve site locally")
 @click.option("-s", "--server", default="localhost", help="Hostname to serve the site at.")
 @click.option("-p", "--port", default=8000, type=int, help="Port to serve the site at.")
-def serve(server, port):
+@click.option("--watch/--no-watch", default=True, help="Enables/Disables watching for changes.")
+def serve(server, port, watch):
     """
     Serve files from deploy_path as a webserver would
     """
@@ -66,7 +68,17 @@ def serve(server, port):
     server_address = (server, port)
     httpd, thread = utils.serve(settings, server_address)
 
+    print("Watch status: %s" % watch)
+    if watch:
+        utils.gen(settings)
+        observer = Observer()
+        handler = utils.FileSystemChangeHandler(settings)
+        observer.schedule(handler, settings["content_path"], recursive=True)
+        observer.schedule(handler, settings["templates"], recursive=True)
+        observer.start()
+
     try:
         thread.join()
     except (KeyboardInterrupt, SystemExit):
         httpd.shutdown()
+        observer.join()

--- a/exhibition/utils.py
+++ b/exhibition/utils.py
@@ -25,6 +25,8 @@ import pathlib
 import shutil
 import threading
 
+import watchdog
+
 from .node import Node
 
 logger = logging.getLogger("exhibition")
@@ -42,6 +44,21 @@ def gen(settings):
     for item in root_node.walk(True):
         logger.info("Rendering %s", item.full_url)
         item.render()
+
+
+class FileSystemChangeHandler(watchdog.events.FileSystemEventHandler):
+    """ Handler for changes on the file system """
+    settings = None
+
+    def __init__(self, settings, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.settings = settings
+
+    def on_any_event(self, event):
+        """ An event has happened, re-generate the site """
+        super().on_any_event(event)
+        print("Regenerating website")
+        gen(self.settings)
 
 
 class ExhibitionBaseHTTPRequestHandler(SimpleHTTPRequestHandler):

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         "ruamel.yaml",
         "typogrify",
         "pypandoc",
+        "watchdog",
     ],
     extras_require={
         "docs": [


### PR DESCRIPTION
This addresses bug #63. It adds watchdog (and all python, file watcher which supports the major platforms) to watch for changes in your content or templates and if so re-generate them when using the serve command. It also includes the `--no-watch` flag to retain the old functionality.

Note: This is currently work in progress, it could do with some tests, docs, etc. The PR is just to surface the work until ready for review.